### PR TITLE
infinity quest is already unlocked at level 22

### DIFF
--- a/src/WurzelBot.py
+++ b/src/WurzelBot.py
@@ -622,7 +622,7 @@ class WurzelBot:
             Logger().print('Zu wenig WT')
             return
 
-        if User().get_level() > 23 and User().get_bar() > MINwt:
+        if User().get_level() > 21 and User().get_bar() > MINwt:
             questnr = self.__HTTPConn.initInfinityQuest()['questnr']
             if int(questnr) <= 500:
                 for item in self.__HTTPConn.initInfinityQuest()['questData']['products']:


### PR DESCRIPTION
According to the Wurzelimperium [forum]( https://wurzelforum.wurzelimperium.de/viewtopic.php?t=122782), the infinity quest is already
available at level 22, not at the previously assumed higher level.

Adjusted the level check accordingly.

Forum message in German: _"Die Unendliche Questreihe findest du ab Level 22 (Wurzelimperator) in Schreberlingen."_