### PR TITLE
fix: getting an error when trying to water an adornment

### DIFF
--- a/src/WurzelBot.py
+++ b/src/WurzelBot.py
@@ -622,7 +622,7 @@ class WurzelBot:
             Logger().print('Zu wenig WT')
             return
 
-        if User().get_level() > 23 and User().get_bar() > MINwt:
+        if User().get_level() > 21 and User().get_bar() > MINwt:
             questnr = self.__HTTPConn.initInfinityQuest()['questnr']
             if int(questnr) <= 500:
                 for item in self.__HTTPConn.initInfinityQuest()['questData']['products']:

--- a/src/garden/Http.py
+++ b/src/garden/Http.py
@@ -3,6 +3,8 @@
 
 from src.core.HTTPCommunication import HTTPConnection
 from src.logger.Logger import Logger
+from src.product.Product import CATEGORY_ADORNMENTS
+from src.product.ProductData import ProductData
 from src.product.Products import WEEDS, TREE_STUMP, STONE, MOLE
 import json, re, time
 
@@ -226,6 +228,12 @@ class Http:
         also 24 Stunden + 30 Sekunden (Sicherheit) zurück, wurde das Feld zwar bereits gegossen,
         kann jedoch wieder gegossen werden.
         """
+		#check if field is an adorment, adorments cannot be watered
+        productId = jContent["garden"][str(fieldID)][0]
+        product = ProductData().get_product_by_id(productId)
+        if CATEGORY_ADORNMENTS == product.get_category():
+            return True
+	
         oneDayInSeconds = (24*60*60) + 30
         currentTimeInSeconds = time.time()
         waterDateInSeconds = int(jContent['water'][fieldID-1][1])


### PR DESCRIPTION
When calling `wurzelBot.water()` I am getting the error:
```
Gieße alle Pflanzen im Garten 1.
Failed to water plants in garden
Traceback (most recent call last):
  File "C:\xxxx\WurzelimperiumBot\src\garden\Http.py", line 36, in water_all_plants
    self.__http.get_json_and_check_for_ok(content)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "xxxx\WurzelimperiumBot\src\core\HTTPCommunication.py", line 95, in get_json_and_check_for_ok
    raise JSONError(f"status = {j_content['status']}")
src.core.HttpError.JSONError: 'status = error'
```
This happens because I have **premium** active and I am using `self._user.has_watering_gnome_helper(),` and I have some **adornments** placed in my garden. For some reason the adornments have a last watered timestamp. If only adornments return the last watered timestamp and no other plants, we get the error.

To prevent this error, I added a check to verify whether the field is an adornment.